### PR TITLE
feat: add app icon and logo component

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import { auth, signOut } from "@/lib/auth";
+import { Logo } from "@/components/logo";
 import Link from "next/link";
 
 export default async function DashboardLayout({
@@ -12,7 +13,8 @@ export default async function DashboardLayout({
     <div className="flex min-h-screen flex-col">
       <header className="border-b border-gray-200 bg-white px-6 py-3">
         <div className="mx-auto flex max-w-5xl items-center justify-between">
-          <Link href="/dashboard" className="text-lg font-bold text-blue-600">
+          <Link href="/dashboard" className="flex items-center gap-2 text-lg font-bold text-blue-600">
+            <Logo size={28} />
             TaskFlow
           </Link>
           <div className="flex items-center gap-4">

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Fond arrondi -->
+  <rect width="32" height="32" rx="8" fill="url(#bg)"/>
+
+  <!-- Clipboard body -->
+  <rect x="8" y="9" width="16" height="18" rx="2" fill="white" opacity="0.15"/>
+  <rect x="8" y="9" width="16" height="18" rx="2" fill="none" stroke="white" stroke-width="1.2" opacity="0.6"/>
+
+  <!-- Clip en haut -->
+  <rect x="13" y="7" width="6" height="4" rx="1.5" fill="white" opacity="0.8"/>
+
+  <!-- Ligne 1 : cochée -->
+  <rect x="11" y="14" width="3.5" height="3.5" rx="1" fill="white" opacity="0.3"/>
+  <path d="M11.7 15.7 L12.8 16.8 L14.5 14.5" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <rect x="16.5" y="15.2" width="5.5" height="1.5" rx="0.75" fill="white" opacity="0.7"/>
+
+  <!-- Ligne 2 : cochée -->
+  <rect x="11" y="19" width="3.5" height="3.5" rx="1" fill="white" opacity="0.3"/>
+  <path d="M11.7 20.7 L12.8 21.8 L14.5 19.5" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <rect x="16.5" y="20.2" width="4" height="1.5" rx="0.75" fill="white" opacity="0.5"/>
+</svg>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,14 @@
 import { signIn } from "@/lib/auth";
+import { Logo } from "@/components/logo";
 
 export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="w-full max-w-sm rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
-        <h1 className="mb-2 text-2xl font-bold text-gray-900">TaskFlow</h1>
+        <div className="mb-4 flex items-center gap-3">
+          <Logo size={36} />
+          <h1 className="text-2xl font-bold text-gray-900">TaskFlow</h1>
+        </div>
         <p className="mb-6 text-sm text-gray-500">
           Connectez-vous pour accéder à vos projets
         </p>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,0 +1,27 @@
+export function Logo({ size = 28 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+    >
+      <defs>
+        <linearGradient id="logoBg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#2563eb" />
+          <stop offset="100%" stopColor="#7c3aed" />
+        </linearGradient>
+      </defs>
+      <rect width="32" height="32" rx="8" fill="url(#logoBg)" />
+      <rect x="8" y="9" width="16" height="18" rx="2" fill="white" opacity="0.15" />
+      <rect x="8" y="9" width="16" height="18" rx="2" fill="none" stroke="white" strokeWidth="1.2" opacity="0.6" />
+      <rect x="13" y="7" width="6" height="4" rx="1.5" fill="white" opacity="0.8" />
+      <rect x="11" y="14" width="3.5" height="3.5" rx="1" fill="white" opacity="0.3" />
+      <path d="M11.7 15.7 L12.8 16.8 L14.5 14.5" stroke="white" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      <rect x="16.5" y="15.2" width="5.5" height="1.5" rx="0.75" fill="white" opacity="0.7" />
+      <rect x="11" y="19" width="3.5" height="3.5" rx="1" fill="white" opacity="0.3" />
+      <path d="M11.7 20.7 L12.8 21.8 L14.5 19.5" stroke="white" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      <rect x="16.5" y="20.2" width="4" height="1.5" rx="0.75" fill="white" opacity="0.5" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Icône SVG favicon (clipboard/checklist, dégradé bleu → violet)
- Composant `Logo` réutilisable
- Logo intégré dans le header dashboard et la page login

## Test plan
- [ ] Favicon visible dans l'onglet du navigateur
- [ ] Logo visible dans le header
- [ ] Logo visible sur la page login

🤖 Generated with [Claude Code](https://claude.com/claude-code)