### PR TITLE
fix: exclude icon.svg from auth middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,5 +17,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|icon.svg).*)"],
 };


### PR DESCRIPTION
## Problème
`/icon.svg` était intercepté par le middleware auth et redirigé vers `/login` — le favicon ne se chargeait pas sur prod.

## Fix
Ajout de `icon.svg` dans le matcher d'exclusion du middleware, comme `favicon.ico`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)