### PR TITLE
Release — fix favicon middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,5 +17,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|icon.svg).*)"],
 };


### PR DESCRIPTION
Fix favicon non chargé sur prod (icon.svg intercepté par le middleware auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)